### PR TITLE
add rw permission to the ~/.config/wezterm directory

### DIFF
--- a/org.wezfurlong.wezterm.json
+++ b/org.wezfurlong.wezterm.json
@@ -10,6 +10,7 @@
     "finish-args": [
         "--share=ipc",
         "--filesystem=home:ro",
+        "--filesystem=xdg-config/wezterm",
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",


### PR DESCRIPTION
This makes for an easy migration path for users as now this Flatpak will load their existing configuration, instead of having to copy/move their configuration to ~/.var/app/org.wezfurlong.wezterm/config